### PR TITLE
remove bottle :unneeded

### DIFF
--- a/grype.rb
+++ b/grype.rb
@@ -6,7 +6,6 @@ class Grype < Formula
   desc "A vulnerability scanner for container images and filesystems"
   homepage "https://github.com/anchore/grype"
   version "0.30.0"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the anchore/grype tap (not Homebrew/brew or Homebrew/core):
```