### PR TITLE
chore: Add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Homebrew Formula for Grype
+
+This repo contains the [Homebrew](https://brew.sh/) formula for
+[Grype](https://github.com/anchore/grype)
+
+## Installation
+
+```sh
+brew tap anchore/grype
+brew install grype
+```
+
+## Issues, Feature Requests, etc...
+
+If you have any problems related to the installation of Grype via Homebrew,
+please [open an issue](https://github.com/anchore/homebrew-grype/issues/new)
+
+Any issues or feature requests related to Grype itself should be filed in the
+[Grype repo](https://github.com/anchore/grype)
+


### PR DESCRIPTION
Mirroring the change in the homebrew-syft repo (https://github.com/anchore/homebrew-syft/commits/ee5d6ed8fadf31f83f0baf5fe6fadb795177458c)

Add a minimal README with instructions, mostly because searching `homebrew grype` will show this repo before the main grype repo